### PR TITLE
Adjust installation process to be compatible with PHP 7.1 thru 7.3. Add Composer version as build argument.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,18 @@ FROM php:7-cli
 
 MAINTAINER Yannick Pereira-Reis <yannick.pereira.reis@gmail.com>
 
+ARG COMPOSER_VERSION=
+
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libmcrypt-dev \
-    libpng12-dev \
+    libpng-dev \
+    libzip-dev \
     libbz2-dev \
-    php-pear \
+    libicu-dev \
     curl \
     git \
     subversion \
@@ -19,14 +21,20 @@ RUN apt-get update && \
     sudo \
   && rm -r /var/lib/apt/lists/*
 
-RUN docker-php-ext-install mcrypt zip bz2 mbstring \
+RUN docker-php-ext-install zip bz2 mbstring intl \
   && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install gd
 
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
 RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezone.ini
 RUN php --version
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('sha384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN [ ! -z "${COMPOSER_VERSION}" ] \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version="${COMPOSER_VERSION}" \
+  || php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN php -r "unlink('composer-setup.php');"
 RUN composer --version
 
 # PRESTISSIMOOOOOOOOOO !!


### PR DESCRIPTION
Building an image from the current version of Dockerfile fails. This change-set adjusts Dockerfile to work with PHP 7.1 thru 7.3 and adds Composer version as an optional build argument.